### PR TITLE
Persist dropped dive fields, add frontend tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push to the same branch makes the in-flight run obsolete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/backend/go.mod
+          cache-dependency-path: apps/backend/go.sum
+
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      # The backend suite is self-contained and needs no database.
+      - name: Test
+        run: go test -race ./...
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      # Also runs tsc -b, so this covers the typecheck.
+      - name: Build
+        run: bun run build
+
+      # Invoked through npx rather than bun so it runs under Node: Bun's runtime
+      # does not implement the node:inspector API that coverage-v8 needs.
+      - name: Test
+        run: npx vitest run --coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,20 @@ bun dev              # Start development server
 bun run build        # Build for production (runs tsc -b && vite build)  
 bun run lint         # Run ESLint
 bun run preview      # Preview production build
+bun run test         # Run the Vitest suite once
+bun run test:watch   # Run Vitest in watch mode
+
+# Coverage must run under Node, not Bun - Bun's runtime does not implement the
+# node:inspector coverage API that @vitest/coverage-v8 depends on.
+npx vitest run --coverage
 ```
+
+### Frontend Testing
+- **Runner**: Vitest, `node` environment (the covered modules are pure logic, no DOM)
+- Tests live beside their module as `src/**/*.test.ts`
+- The suite runs with `TZ=Pacific/Kiritimati` (UTC+14) on purpose: dive times are
+  wall-clock times at the dive site, so an accidental UTC conversion shifts the
+  date and fails a test instead of passing by luck on a UTC machine
 
 ### Backend (apps/backend/)
 ```bash

--- a/apps/backend/handlers/dives.go
+++ b/apps/backend/handlers/dives.go
@@ -5,6 +5,7 @@ import (
 	"divelog-backend/models"
 	"divelog-backend/utils"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -319,4 +320,28 @@ func (h *DiveHandler) DeleteDive(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Dive deleted successfully"})
+}
+
+// DeleteAllDives removes every dive for the user. This is a development-only
+// helper for resetting test data and is not registered in release mode.
+func (h *DiveHandler) DeleteAllDives(c *gin.Context) {
+	userID, ok := middleware.RequireUserID(c)
+	if !ok {
+		return
+	}
+
+	deleted, err := h.diveRepo.DeleteAllDives(c.Request.Context(), userID)
+	if err != nil {
+		utils.LogError(c.Request.Context(), "Error deleting all dives", err, utils.UserID(userID))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete dives"})
+		return
+	}
+
+	utils.LogInfo(c.Request.Context(), "Deleted all dives for user",
+		utils.UserID(userID), slog.Int64("deleted_count", deleted))
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":       "All dives deleted successfully",
+		"deleted_count": deleted,
+	})
 }

--- a/apps/backend/handlers/dives_test.go
+++ b/apps/backend/handlers/dives_test.go
@@ -40,6 +40,11 @@ func (m *mockDiveRepository) DeleteDive(ctx context.Context, diveID, userID int)
 	return m.Called(ctx, diveID, userID).Error(0)
 }
 
+func (m *mockDiveRepository) DeleteAllDives(ctx context.Context, userID int) (int64, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *mockDiveRepository) GetCurrentDive(ctx context.Context, diveID, userID int) (*models.Dive, error) {
 	args := m.Called(ctx, diveID, userID)
 	if args.Get(0) == nil {
@@ -215,4 +220,35 @@ func TestDiveHandlerCreateDiveRejectsMalformedJSON(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.JSONEq(t, `{"error":"invalid_request","message":"Request body must contain valid JSON"}`, recorder.Body.String())
+}
+
+func TestDiveHandlerDeleteAllDivesReturnsDeletedCount(t *testing.T) {
+	diveRepo := new(mockDiveRepository)
+	handler := NewDiveHandler(diveRepo, new(mockDiveSiteRepository))
+
+	diveRepo.On("DeleteAllDives", mock.Anything, 1).Return(int64(12), nil)
+
+	context, recorder := setupGinContext(http.MethodDelete, "/dives", nil)
+	handler.DeleteAllDives(context)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var response struct {
+		DeletedCount int64 `json:"deleted_count"`
+	}
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, int64(12), response.DeletedCount)
+	diveRepo.AssertExpectations(t)
+}
+
+func TestDiveHandlerDeleteAllDivesReportsRepositoryFailure(t *testing.T) {
+	diveRepo := new(mockDiveRepository)
+	handler := NewDiveHandler(diveRepo, new(mockDiveSiteRepository))
+
+	diveRepo.On("DeleteAllDives", mock.Anything, 1).Return(int64(0), assert.AnError)
+
+	context, recorder := setupGinContext(http.MethodDelete, "/dives", nil)
+	handler.DeleteAllDives(context)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	diveRepo.AssertExpectations(t)
 }

--- a/apps/backend/handlers/repositories.go
+++ b/apps/backend/handlers/repositories.go
@@ -11,6 +11,7 @@ type diveRepository interface {
 	CreateMultipleDives(context.Context, []*models.Dive) ([]models.Dive, []map[string]interface{}, error)
 	UpdateDive(context.Context, int, int, *models.Dive) error
 	DeleteDive(context.Context, int, int) error
+	DeleteAllDives(context.Context, int) (int64, error)
 	GetCurrentDive(context.Context, int, int) (*models.Dive, error)
 	CheckDuplicateDive(context.Context, int, int, string) (bool, error)
 	CheckDuplicateDiveForUpdateByLocation(context.Context, int, float64, float64, string, int) (bool, error)

--- a/apps/backend/main.go
+++ b/apps/backend/main.go
@@ -94,6 +94,12 @@ func main() {
 			diveRoutes.POST("/batch", diveHandler.CreateMultipleDives)
 			diveRoutes.PUT("/:id", diveHandler.UpdateDive)
 			diveRoutes.DELETE("/:id", diveHandler.DeleteDive)
+
+			// Development-only helper for wiping test data. Deliberately not
+			// registered in release mode, so it cannot be reached in production.
+			if cfg.GinMode != "release" {
+				diveRoutes.DELETE("", diveHandler.DeleteAllDives)
+			}
 		}
 
 		// Dive site endpoints (no user validation needed for these)

--- a/apps/backend/repository/dive_repository.go
+++ b/apps/backend/repository/dive_repository.go
@@ -17,12 +17,43 @@ func NewDiveRepository(db *sql.DB) *DiveRepository {
 	return &DiveRepository{db: db}
 }
 
+// jsonbParam returns a value for a JSONB column, storing NULL for empty payloads.
+func jsonbParam(payload []byte) interface{} {
+	if len(payload) == 0 {
+		return nil
+	}
+	return payload
+}
+
+// marshalDiveJSON serializes the JSONB-backed fields of a dive.
+func marshalDiveJSON(dive *models.Dive) (samples, equipment, conditions, safetyStops interface{}, err error) {
+	samplesJSON, err := utils.MarshalJSON(dive.Samples)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	equipmentJSON, err := utils.MarshalJSON(dive.Equipment)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	conditionsJSON, err := utils.MarshalJSON(dive.Conditions)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	safetyStopsJSON, err := utils.MarshalJSON(dive.SafetyStops)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return jsonbParam(samplesJSON), jsonbParam(equipmentJSON),
+		jsonbParam(conditionsJSON), jsonbParam(safetyStopsJSON), nil
+}
+
 // GetDivesByUserID retrieves all dives for a user
 func (r *DiveRepository) GetDivesByUserID(ctx context.Context, userID int) ([]models.Dive, error) {
 	query := `
 		SELECT 
 			d.id, d.user_id, d.dive_site_id, d.dive_datetime, d.max_depth, d.duration, 
-			d.buddy, d.water_temperature, d.visibility, d.notes, d.samples, d.equipment, d.created_at, d.updated_at,
+			d.buddy, d.water_temperature, d.visibility, d.notes, d.samples, d.equipment,
+			d.conditions, d.dive_type, d.rating, d.safety_stops, d.created_at, d.updated_at,
 			COALESCE(ds.latitude, d.latitude, 0.0) as latitude,
 			COALESCE(ds.longitude, d.longitude, 0.0) as longitude,
 			COALESCE(ds.name, d.location, 'Unknown Location') as location
@@ -59,23 +90,15 @@ func (r *DiveRepository) GetDivesByUserID(ctx context.Context, userID int) ([]mo
 
 // CreateDive creates a new dive
 func (r *DiveRepository) CreateDive(ctx context.Context, dive *models.Dive) error {
-	// Serialize samples to JSON
-	samplesJSON, err := utils.MarshalJSON(dive.Samples)
+	samplesParam, equipmentParam, conditionsParam, safetyStopsParam, err := marshalDiveJSON(dive)
 	if err != nil {
-		utils.LogError(ctx, "Error marshaling samples", err, utils.UserID(dive.UserID))
-		return utils.ErrProcessingFailed
-	}
-
-	// Serialize equipment to JSON
-	equipmentJSON, err := utils.MarshalJSON(dive.Equipment)
-	if err != nil {
-		utils.LogError(ctx, "Error marshaling equipment", err, utils.UserID(dive.UserID))
+		utils.LogError(ctx, "Error marshaling dive JSON fields", err, utils.UserID(dive.UserID))
 		return utils.ErrProcessingFailed
 	}
 
 	query := `
-		INSERT INTO dives (user_id, dive_site_id, dive_datetime, max_depth, duration, buddy, latitude, longitude, location, water_temperature, visibility, notes, samples, equipment, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		INSERT INTO dives (user_id, dive_site_id, dive_datetime, max_depth, duration, buddy, latitude, longitude, location, water_temperature, visibility, notes, samples, equipment, conditions, dive_type, rating, safety_stops, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 		RETURNING id, created_at, updated_at
 	`
 
@@ -84,7 +107,8 @@ func (r *DiveRepository) CreateDive(ctx context.Context, dive *models.Dive) erro
 		query,
 		dive.UserID, dive.DiveSiteID, dive.DateTime, dive.MaxDepth, dive.Duration,
 		dive.Buddy, dive.Latitude, dive.Longitude, dive.Location,
-		dive.WaterTemp, dive.Visibility, dive.Notes, samplesJSON, equipmentJSON,
+		dive.WaterTemp, dive.Visibility, dive.Notes, samplesParam, equipmentParam,
+		conditionsParam, dive.DiveType, dive.Rating, safetyStopsParam,
 		now, now,
 	).Scan(&dive.ID, &dive.CreatedAt, &dive.UpdatedAt)
 
@@ -109,40 +133,24 @@ func (r *DiveRepository) CreateMultipleDives(ctx context.Context, dives []*model
 	now := time.Now()
 
 	for _, dive := range dives {
-		// Serialize samples and equipment
-		samplesJSON, err := utils.MarshalJSON(dive.Samples)
+		samplesParam, equipmentParam, conditionsParam, safetyStopsParam, err := marshalDiveJSON(dive)
 		if err != nil {
-			utils.LogError(ctx, "Error marshaling samples in batch", err, slog.Int("dive_count", len(dives)))
-			return nil, nil, utils.ErrProcessingFailed
-		}
-
-		equipmentJSON, err := utils.MarshalJSON(dive.Equipment)
-		if err != nil {
-			utils.LogError(ctx, "Error marshaling equipment in batch", err, slog.Int("dive_count", len(dives)))
+			utils.LogError(ctx, "Error marshaling dive JSON fields in batch", err, slog.Int("dive_count", len(dives)))
 			return nil, nil, utils.ErrProcessingFailed
 		}
 
 		query := `
-			INSERT INTO dives (user_id, dive_site_id, dive_datetime, max_depth, duration, buddy, latitude, longitude, location, water_temperature, visibility, notes, samples, equipment, created_at, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			INSERT INTO dives (user_id, dive_site_id, dive_datetime, max_depth, duration, buddy, latitude, longitude, location, water_temperature, visibility, notes, samples, equipment, conditions, dive_type, rating, safety_stops, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 			RETURNING id, created_at, updated_at
 		`
-
-		var samplesParam interface{} = nil
-		if len(samplesJSON) > 0 {
-			samplesParam = samplesJSON
-		}
-
-		var equipmentParam interface{} = nil
-		if len(equipmentJSON) > 0 {
-			equipmentParam = equipmentJSON
-		}
 
 		err = tx.QueryRow(
 			query,
 			dive.UserID, dive.DiveSiteID, dive.DateTime, dive.MaxDepth, dive.Duration,
 			dive.Buddy, dive.Latitude, dive.Longitude, dive.Location,
 			dive.WaterTemp, dive.Visibility, dive.Notes, samplesParam, equipmentParam,
+			conditionsParam, dive.DiveType, dive.Rating, safetyStopsParam,
 			now, now,
 		).Scan(&dive.ID, &dive.CreatedAt, &dive.UpdatedAt)
 
@@ -164,48 +172,38 @@ func (r *DiveRepository) CreateMultipleDives(ctx context.Context, dives []*model
 
 // UpdateDive updates an existing dive
 func (r *DiveRepository) UpdateDive(ctx context.Context, diveID, userID int, dive *models.Dive) error {
-	// Serialize samples and equipment
-	samplesJSON, err := utils.MarshalJSON(dive.Samples)
-	if err != nil {
-		return utils.ErrProcessingFailed
-	}
-
-	equipmentJSON, err := utils.MarshalJSON(dive.Equipment)
+	samplesParam, equipmentParam, conditionsParam, safetyStopsParam, err := marshalDiveJSON(dive)
 	if err != nil {
 		return utils.ErrProcessingFailed
 	}
 
 	query := `
-		UPDATE dives 
-		SET dive_site_id = $1, dive_datetime = $2, max_depth = $3, duration = $4, buddy = $5, 
-		    latitude = $6, longitude = $7, location = $8, water_temperature = $9, visibility = $10, notes = $11, samples = $12, equipment = $13, updated_at = $14
-		WHERE id = $15 AND user_id = $16
-		RETURNING id, user_id, dive_datetime, max_depth, duration, buddy, 
-		          water_temperature, visibility, notes, samples, equipment, created_at, updated_at
+		UPDATE dives
+		SET dive_site_id = $1, dive_datetime = $2, max_depth = $3, duration = $4, buddy = $5,
+		    latitude = $6, longitude = $7, location = $8, water_temperature = $9, visibility = $10, notes = $11, samples = $12, equipment = $13,
+		    conditions = $14, dive_type = $15, rating = $16, safety_stops = $17, updated_at = $18
+		WHERE id = $19 AND user_id = $20
+		RETURNING id, user_id, dive_datetime, max_depth, duration, buddy,
+		          water_temperature, visibility, notes, samples, equipment,
+		          conditions, dive_type, rating, safety_stops, created_at, updated_at
 	`
 
 	var samplesJSONOut []byte
 	var equipmentJSONOut []byte
+	var conditionsJSONOut []byte
+	var safetyStopsJSONOut []byte
 	now := time.Now()
-
-	var samplesParam interface{} = nil
-	if len(samplesJSON) > 0 {
-		samplesParam = samplesJSON
-	}
-
-	var equipmentParam interface{} = nil
-	if len(equipmentJSON) > 0 {
-		equipmentParam = equipmentJSON
-	}
 
 	err = r.db.QueryRow(
 		query,
 		dive.DiveSiteID, dive.DateTime, dive.MaxDepth, dive.Duration, dive.Buddy,
-		dive.Latitude, dive.Longitude, dive.Location, dive.WaterTemp, dive.Visibility, dive.Notes, samplesParam, equipmentParam, now,
+		dive.Latitude, dive.Longitude, dive.Location, dive.WaterTemp, dive.Visibility, dive.Notes, samplesParam, equipmentParam,
+		conditionsParam, dive.DiveType, dive.Rating, safetyStopsParam, now,
 		diveID, userID,
 	).Scan(
 		&dive.ID, &dive.UserID, &dive.DateTime, &dive.MaxDepth, &dive.Duration,
 		&dive.Buddy, &dive.WaterTemp, &dive.Visibility, &dive.Notes, &samplesJSONOut, &equipmentJSONOut,
+		&conditionsJSONOut, &dive.DiveType, &dive.Rating, &safetyStopsJSONOut,
 		&dive.CreatedAt, &dive.UpdatedAt,
 	)
 
@@ -217,15 +215,31 @@ func (r *DiveRepository) UpdateDive(ctx context.Context, diveID, userID int, div
 		return utils.ErrDatabaseError
 	}
 
-	// Parse samples and equipment JSON
-	if samplesJSONOut != nil {
-		utils.UnmarshalJSON(samplesJSONOut, &dive.Samples)
-	}
-	if equipmentJSONOut != nil {
-		utils.UnmarshalJSON(equipmentJSONOut, &dive.Equipment)
-	}
+	// Parse the JSONB-backed fields
+	utils.UnmarshalJSON(samplesJSONOut, &dive.Samples)
+	utils.UnmarshalJSON(equipmentJSONOut, &dive.Equipment)
+	utils.UnmarshalJSON(conditionsJSONOut, &dive.Conditions)
+	utils.UnmarshalJSON(safetyStopsJSONOut, &dive.SafetyStops)
 
 	return nil
+}
+
+// DeleteAllDives removes every dive belonging to a user and reports how many
+// rows were removed. Intended for resetting local test data.
+func (r *DiveRepository) DeleteAllDives(ctx context.Context, userID int) (int64, error) {
+	result, err := r.db.ExecContext(ctx, `DELETE FROM dives WHERE user_id = $1`, userID)
+	if err != nil {
+		utils.LogError(ctx, "Error deleting all dives", err, utils.UserID(userID))
+		return 0, utils.ErrDatabaseError
+	}
+
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		utils.LogError(ctx, "Error getting rows affected", err, utils.UserID(userID))
+		return 0, utils.ErrDatabaseError
+	}
+
+	return deleted, nil
 }
 
 // DeleteDive deletes a dive
@@ -269,17 +283,17 @@ func (r *DiveRepository) GetCurrentDive(ctx context.Context, diveID, userID int)
 	return &dive, nil
 }
 
-// CheckDuplicateDive checks if a dive already exists for the same user, date, and dive site
+// CheckDuplicateDive checks if a dive already exists for the same user, start
+// time, and dive site. Matching on the full timestamp rather than the date
+// keeps repeat dives at one site on the same day as distinct dives.
 func (r *DiveRepository) CheckDuplicateDive(ctx context.Context, userID int, diveSiteID int, diveDateTime string) (bool, error) {
-	// Parse the datetime and extract just the date part for comparison
 	dt := utils.ParseDateTime(diveDateTime)
-	dateOnly := dt.Format("2006-01-02")
 
-	query := `SELECT COUNT(*) FROM dives 
-			  WHERE user_id = $1 AND dive_site_id = $2 AND DATE(dive_datetime) = $3`
+	query := `SELECT COUNT(*) FROM dives
+			  WHERE user_id = $1 AND dive_site_id = $2 AND dive_datetime = $3`
 
 	var count int
-	err := r.db.QueryRow(query, userID, diveSiteID, dateOnly).Scan(&count)
+	err := r.db.QueryRow(query, userID, diveSiteID, dt).Scan(&count)
 	if err != nil {
 		return false, utils.ErrDatabaseError
 	}
@@ -320,24 +334,26 @@ func (r *DiveRepository) scanDive(rows *sql.Rows) (*models.Dive, error) {
 	var dive models.Dive
 	var samplesJSON []byte
 	var equipmentJSON []byte
+	var conditionsJSON []byte
+	var safetyStopsJSON []byte
 
 	err := rows.Scan(
 		&dive.ID, &dive.UserID, &dive.DiveSiteID, &dive.DateTime, &dive.MaxDepth,
 		&dive.Duration, &dive.Buddy, &dive.WaterTemp, &dive.Visibility,
-		&dive.Notes, &samplesJSON, &equipmentJSON, &dive.CreatedAt, &dive.UpdatedAt,
+		&dive.Notes, &samplesJSON, &equipmentJSON,
+		&conditionsJSON, &dive.DiveType, &dive.Rating, &safetyStopsJSON,
+		&dive.CreatedAt, &dive.UpdatedAt,
 		&dive.Latitude, &dive.Longitude, &dive.Location,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse samples and equipment JSON
-	if samplesJSON != nil {
-		utils.UnmarshalJSON(samplesJSON, &dive.Samples)
-	}
-	if equipmentJSON != nil {
-		utils.UnmarshalJSON(equipmentJSON, &dive.Equipment)
-	}
+	// Parse the JSONB-backed fields
+	utils.UnmarshalJSON(samplesJSON, &dive.Samples)
+	utils.UnmarshalJSON(equipmentJSON, &dive.Equipment)
+	utils.UnmarshalJSON(conditionsJSON, &dive.Conditions)
+	utils.UnmarshalJSON(safetyStopsJSON, &dive.SafetyStops)
 
 	return &dive, nil
 }

--- a/apps/backend/repository/dive_repository_test.go
+++ b/apps/backend/repository/dive_repository_test.go
@@ -3,11 +3,16 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"divelog-backend/models"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Note: These are integration tests that require a test database
@@ -28,7 +33,7 @@ func TestDiveRepository_CreateDive(t *testing.T) {
 	defer db.Close()
 
 	repo := NewDiveRepository(db)
-	
+
 	dive := &models.Dive{
 		UserID:    1,
 		DateTime:  models.LocalTime{Time: time.Now()},
@@ -57,7 +62,7 @@ func TestDiveRepository_GetDivesByUserID(t *testing.T) {
 	defer db.Close()
 
 	repo := NewDiveRepository(db)
-	
+
 	dives, err := repo.GetDivesByUserID(context.Background(), 1)
 	if err != nil {
 		t.Errorf("GetDivesByUserID failed: %v", err)
@@ -81,8 +86,56 @@ func TestDiveValidation(t *testing.T) {
 	if dive.MaxDepth < 0 {
 		t.Log("Correctly identified negative depth as invalid")
 	}
-	
+
 	if dive.Duration <= 0 {
 		t.Log("Correctly identified zero/negative duration as invalid")
 	}
+}
+
+type deleteAllTestDriver struct {
+	result driver.Result
+	err    error
+	query  string
+	args   []driver.NamedValue
+}
+
+func (d *deleteAllTestDriver) Open(string) (driver.Conn, error) {
+	return &deleteAllTestConn{driver: d}, nil
+}
+
+type deleteAllTestConn struct {
+	driver *deleteAllTestDriver
+}
+
+func (c *deleteAllTestConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *deleteAllTestConn) Close() error { return nil }
+
+func (c *deleteAllTestConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *deleteAllTestConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.driver.query = query
+	c.driver.args = args
+	return c.driver.result, c.driver.err
+}
+
+func TestDiveRepositoryDeleteAllDivesScopesDeleteToUser(t *testing.T) {
+	testDriver := &deleteAllTestDriver{result: driver.RowsAffected(7)}
+	driverName := fmt.Sprintf("delete-all-dives-success-%d", time.Now().UnixNano())
+	sql.Register(driverName, testDriver)
+	db, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	deleted, err := NewDiveRepository(db).DeleteAllDives(context.Background(), 42)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), deleted)
+	assert.Equal(t, "DELETE FROM dives WHERE user_id = $1", testDriver.query)
+	require.Len(t, testDriver.args, 1)
+	assert.Equal(t, int64(42), testDriver.args[0].Value)
 }

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Test coverage output
+coverage
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/apps/frontend/bun.lock
+++ b/apps/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",

--- a/apps/frontend/bun.lock
+++ b/apps/frontend/bun.lock
@@ -45,6 +45,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -53,6 +54,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
+        "vitest": "^4.1.10",
       },
     },
   },
@@ -96,6 +98,8 @@
     "@babel/traverse": ["@babel/traverse@7.27.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.27.3", "@babel/parser": "^7.27.4", "@babel/template": "^7.27.2", "@babel/types": "^7.27.3", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA=="],
 
     "@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA=="],
 
@@ -195,9 +199,9 @@
 
     "@jridgewell/set-array": ["@jridgewell/set-array@1.2.1", "", {}, "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="],
 
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
@@ -349,6 +353,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.42.0", "", { "os": "win32", "cpu": "x64" }, "sha512-LpHiJRwkaVz/LqjHjK8LCi8osq7elmpwujwbXKNW88bM8eeGxavJIKKjkjpMHAh/2xfnrt1ZSnhTv41WYUHYmA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@tailwindcss/cli": ["@tailwindcss/cli@4.0.0", "", { "dependencies": { "@parcel/watcher": "^2.5.0", "@tailwindcss/node": "^4.0.0", "@tailwindcss/oxide": "^4.0.0", "enhanced-resolve": "^5.18.0", "lightningcss": "^1.29.1", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.0.0" }, "bin": { "tailwindcss": "dist/index.mjs" } }, "sha512-nh6kzSTalHf9yk6WNsS4MMZakSINsncNQXsSJthvcPI4x+yajEaNQvS2uUti3PGLbsmlGoUvjhnGTBpzh7H0bA=="],
@@ -393,6 +399,10 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
@@ -433,6 +443,22 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.1", "", { "dependencies": { "@babel/core": "^7.26.10", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@rolldown/pluginutils": "1.0.0-beta.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.10", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.10", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.10", "vitest": "4.1.10" }, "optionalPeers": ["@vitest/browser"] }, "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -444,6 +470,10 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA=="],
 
     "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": "bin/autoprefixer" }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
 
@@ -458,6 +488,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -497,6 +529,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
     "esbuild": ["esbuild@0.25.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.5", "@esbuild/android-arm": "0.25.5", "@esbuild/android-arm64": "0.25.5", "@esbuild/android-x64": "0.25.5", "@esbuild/darwin-arm64": "0.25.5", "@esbuild/darwin-x64": "0.25.5", "@esbuild/freebsd-arm64": "0.25.5", "@esbuild/freebsd-x64": "0.25.5", "@esbuild/linux-arm": "0.25.5", "@esbuild/linux-arm64": "0.25.5", "@esbuild/linux-ia32": "0.25.5", "@esbuild/linux-loong64": "0.25.5", "@esbuild/linux-mips64el": "0.25.5", "@esbuild/linux-ppc64": "0.25.5", "@esbuild/linux-riscv64": "0.25.5", "@esbuild/linux-s390x": "0.25.5", "@esbuild/linux-x64": "0.25.5", "@esbuild/netbsd-arm64": "0.25.5", "@esbuild/netbsd-x64": "0.25.5", "@esbuild/openbsd-arm64": "0.25.5", "@esbuild/openbsd-x64": "0.25.5", "@esbuild/sunos-x64": "0.25.5", "@esbuild/win32-arm64": "0.25.5", "@esbuild/win32-ia32": "0.25.5", "@esbuild/win32-x64": "0.25.5" }, "bin": "bin/esbuild" }, "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -521,7 +555,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -567,6 +605,8 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
@@ -585,9 +625,15 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "jiti": ["jiti@2.4.2", "", { "bin": "lib/jiti-cli.mjs" }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
@@ -645,7 +691,11 @@
 
     "lucide-react": ["lucide-react@0.513.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg=="],
 
-    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -673,6 +723,8 @@
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -684,6 +736,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -739,7 +793,13 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -759,7 +819,13 @@
 
     "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -787,7 +853,11 @@
 
     "vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -799,6 +869,12 @@
 
     "zustand": ["zustand@5.0.6", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A=="],
 
+    "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -807,9 +883,15 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
     "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": "bin/detect-libc.js" }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "@tailwindcss/cli/tailwindcss": ["tailwindcss@4.0.0", "", {}, "sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ=="],
+
+    "@tailwindcss/node/magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -819,12 +901,36 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "magicast/@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "magicast/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "make-dir/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "rollup/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "vitest/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vitest/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "@ampproject/remapping/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@babel/generator/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@tailwindcss/node/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "magicast/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "magicast/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "vitest/tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
   }
 }

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.0",
@@ -50,6 +53,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
@@ -57,6 +61,7 @@
     "tw-animate-css": "^1.3.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/frontend/src/lib/api.test.ts
+++ b/apps/frontend/src/lib/api.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { serializeDive } from './api';
+import type { Dive } from './dives';
+
+// The client models are camelCase and the Go API is snake_case. Go silently
+// ignores unknown JSON keys, so a naming mismatch here does not fail loudly -
+// the field just never arrives. These tests assert the wire shape directly.
+const dive = (over: Partial<Dive> = {}): Omit<Dive, 'id'> => ({
+  datetime: '2024-03-15T09:30:00',
+  location: 'Blue Hole',
+  depth: 28.4,
+  duration: 45,
+  lat: 28.5721,
+  lng: 34.5372,
+  ...over,
+});
+
+describe('serializeDive', () => {
+  it('passes through the fields that already match the API', () => {
+    expect(serializeDive(dive({ buddy: 'Jane Diver', notes: 'Great dive', rating: 4 }))).toMatchObject({
+      datetime: '2024-03-15T09:30:00',
+      location: 'Blue Hole',
+      depth: 28.4,
+      duration: 45,
+      lat: 28.5721,
+      lng: 34.5372,
+      buddy: 'Jane Diver',
+      notes: 'Great dive',
+      rating: 4,
+    });
+  });
+
+  it('renames diveType and safetyStops to snake_case', () => {
+    const payload = serializeDive(
+      dive({ diveType: 'technical', safetyStops: [{ depth: 5, duration: 3 }] }),
+    );
+
+    expect(payload).toMatchObject({
+      dive_type: 'technical',
+      safety_stops: [{ depth: 5, duration: 3 }],
+    });
+    expect(payload).not.toHaveProperty('diveType');
+    expect(payload).not.toHaveProperty('safetyStops');
+  });
+
+  it('flattens conditions to the API field names', () => {
+    const payload = serializeDive(
+      dive({
+        conditions: {
+          waterTemp: { surface: 24, bottom: 18 },
+          airTemp: 26,
+          visibility: 20,
+          current: { strength: 'moderate', direction: 'NE' },
+          weather: 'sunny',
+          seaState: 2,
+          surge: 'light',
+        },
+      }),
+    );
+
+    expect(payload.conditions).toEqual({
+      water_temp_surface: 24,
+      water_temp_bottom: 18,
+      air_temp: 26,
+      visibility: 20,
+      current_strength: 'moderate',
+      current_direction: 'NE',
+      weather: 'sunny',
+      sea_state: 2,
+      surge: 'light',
+    });
+  });
+
+  // The dives table has a scalar water_temperature column alongside the
+  // conditions JSON, and bottom temperature is the meaningful one for a dive.
+  it('promotes bottom temperature to the top-level water_temperature', () => {
+    expect(serializeDive(dive({ conditions: { waterTemp: { surface: 24, bottom: 18 } } })))
+      .toMatchObject({ water_temperature: 18 });
+  });
+
+  it('falls back to surface temperature when there is no bottom reading', () => {
+    expect(serializeDive(dive({ conditions: { waterTemp: { surface: 24 } } })))
+      .toMatchObject({ water_temperature: 24 });
+  });
+
+  it('keeps a bottom temperature of zero rather than treating it as missing', () => {
+    expect(serializeDive(dive({ conditions: { waterTemp: { surface: 24, bottom: 0 } } })))
+      .toMatchObject({ water_temperature: 0 });
+  });
+
+  // The API models visibility as a whole number of meters.
+  it('rounds visibility to a whole number at the top level', () => {
+    const payload = serializeDive(dive({ conditions: { visibility: 17.6 } }));
+
+    expect(payload.visibility).toBe(18);
+    expect(payload.conditions?.visibility).toBe(17.6);
+  });
+
+  it('leaves conditions undefined when the dive has none', () => {
+    const payload = serializeDive(dive());
+
+    expect(payload.conditions).toBeUndefined();
+    expect(payload.water_temperature).toBeUndefined();
+    expect(payload.visibility).toBeUndefined();
+  });
+
+  it('serializes equipment and samples unchanged', () => {
+    const equipment = {
+      tanks: [
+        {
+          size: 12,
+          working_pressure: 232,
+          start_pressure: 210,
+          end_pressure: 60,
+          gas_mix: { oxygen: 21, helium: 0, nitrogen: 79, name: 'Air' },
+        },
+      ],
+    };
+    const samples = [{ time: 0, depth: 0 }, { time: 600, depth: 28.4 }];
+
+    expect(serializeDive(dive({ equipment, samples }))).toMatchObject({ equipment, samples });
+  });
+
+  // A round-trip through JSON is what actually goes over the wire, and it is
+  // where undefined values disappear.
+  it('drops undefined optional fields from the JSON body', () => {
+    const body = JSON.parse(JSON.stringify(serializeDive(dive())));
+
+    expect(body).not.toHaveProperty('conditions');
+    expect(body).not.toHaveProperty('dive_type');
+    expect(body).not.toHaveProperty('safety_stops');
+    expect(body).not.toHaveProperty('water_temperature');
+  });
+});

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -84,7 +84,7 @@ export const settingsApi = {
 // The API uses snake_case field names, while the client models are camelCase.
 // Sending a Dive verbatim silently drops conditions, dive type and safety stops,
 // since Go ignores unknown JSON keys.
-const serializeDive = (dive: Omit<Dive, 'id'>) => {
+export const serializeDive = (dive: Omit<Dive, 'id'>) => {
   const { conditions, diveType, safetyStops, ...rest } = dive;
 
   return {

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -81,6 +81,33 @@ export const settingsApi = {
   },
 };
 
+// The API uses snake_case field names, while the client models are camelCase.
+// Sending a Dive verbatim silently drops conditions, dive type and safety stops,
+// since Go ignores unknown JSON keys.
+const serializeDive = (dive: Omit<Dive, 'id'>) => {
+  const { conditions, diveType, safetyStops, ...rest } = dive;
+
+  return {
+    ...rest,
+    dive_type: diveType,
+    safety_stops: safetyStops,
+    water_temperature: conditions?.waterTemp?.bottom ?? conditions?.waterTemp?.surface,
+    // The API models visibility as a whole number of meters
+    visibility: conditions?.visibility !== undefined ? Math.round(conditions.visibility) : undefined,
+    conditions: conditions && {
+      water_temp_surface: conditions.waterTemp?.surface,
+      water_temp_bottom: conditions.waterTemp?.bottom,
+      air_temp: conditions.airTemp,
+      visibility: conditions.visibility,
+      current_strength: conditions.current?.strength,
+      current_direction: conditions.current?.direction,
+      weather: conditions.weather,
+      sea_state: conditions.seaState,
+      surge: conditions.surge,
+    },
+  };
+};
+
 // API utility functions for dives
 export const divesApi = {
   // Fetch all dives from backend
@@ -113,7 +140,7 @@ export const divesApi = {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(dive),
+        body: JSON.stringify(serializeDive(dive)),
       });
 
       if (!response.ok) {
@@ -136,7 +163,7 @@ export const divesApi = {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(dives),
+        body: JSON.stringify(dives.map(serializeDive)),
       });
 
       if (!response.ok) {
@@ -159,7 +186,7 @@ export const divesApi = {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(dive),
+        body: JSON.stringify(serializeDive(dive)),
       });
 
       if (!response.ok) {
@@ -191,6 +218,29 @@ export const divesApi = {
       return { data: undefined };
     } catch (error) {
       console.error('Failed to delete dive:', error);
+      return { error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  },
+
+  // Delete every dive for the user. Development only - the backend does not
+  // register this route in release mode.
+  async deleteAllDives(): Promise<ApiResponse<{ deleted_count: number }>> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/dives?user_id=${DEFAULT_USER_ID}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return { data };
+    } catch (error) {
+      console.error('Failed to delete all dives:', error);
       return { error: error instanceof Error ? error.message : 'Unknown error' };
     }
   },

--- a/apps/frontend/src/lib/diveStats.test.ts
+++ b/apps/frontend/src/lib/diveStats.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateDiveStatistics,
+  formatDuration,
+  getDivesByMonth,
+  getRecentDives,
+} from './diveStats';
+import type { Dive } from './dives';
+
+const dive = (over: Partial<Dive> = {}): Dive => ({
+  id: 1,
+  datetime: '2024-03-15T09:30:00',
+  location: 'Blue Hole',
+  depth: 28.4,
+  duration: 45,
+  lat: 0,
+  lng: 0,
+  ...over,
+});
+
+describe('calculateDiveStatistics', () => {
+  // The dashboard renders these straight into stat tiles, so the empty case has
+  // to produce real zeros rather than NaN from dividing by an empty list.
+  it('returns zeroed stats for an empty log', () => {
+    expect(calculateDiveStatistics([])).toEqual({
+      totalDives: 0,
+      totalBottomTime: 0,
+      maxDepth: 0,
+      avgDepth: 0,
+      uniqueLocations: 0,
+      lastDiveDate: null,
+      deepestDive: null,
+      longestDive: null,
+    });
+  });
+
+  it('aggregates count, bottom time and depth', () => {
+    const stats = calculateDiveStatistics([
+      dive({ id: 1, depth: 30, duration: 45 }),
+      dive({ id: 2, depth: 18, duration: 52 }),
+      dive({ id: 3, depth: 12, duration: 38 }),
+    ]);
+
+    expect(stats.totalDives).toBe(3);
+    expect(stats.totalBottomTime).toBe(135);
+    expect(stats.maxDepth).toBe(30);
+    expect(stats.avgDepth).toBe(20);
+  });
+
+  it('rounds average depth to one decimal', () => {
+    const stats = calculateDiveStatistics([
+      dive({ id: 1, depth: 10 }),
+      dive({ id: 2, depth: 11 }),
+      dive({ id: 3, depth: 13 }),
+    ]);
+
+    expect(stats.avgDepth).toBe(11.3);
+  });
+
+  it('counts distinct locations', () => {
+    const stats = calculateDiveStatistics([
+      dive({ id: 1, location: 'Blue Hole' }),
+      dive({ id: 2, location: 'Thistlegorm' }),
+      dive({ id: 3, location: 'Blue Hole' }),
+    ]);
+
+    expect(stats.uniqueLocations).toBe(2);
+  });
+
+  it('reports the most recent dive date regardless of input order', () => {
+    const stats = calculateDiveStatistics([
+      dive({ id: 1, datetime: '2024-03-15T09:30:00' }),
+      dive({ id: 2, datetime: '2024-06-01T08:00:00' }),
+      dive({ id: 3, datetime: '2024-01-02T14:00:00' }),
+    ]);
+
+    expect(stats.lastDiveDate).toBe('2024-06-01T08:00:00');
+  });
+
+  it('identifies the deepest and longest dives', () => {
+    const stats = calculateDiveStatistics([
+      dive({ id: 1, depth: 30, duration: 20 }),
+      dive({ id: 2, depth: 12, duration: 62 }),
+    ]);
+
+    expect(stats.deepestDive?.id).toBe(1);
+    expect(stats.longestDive?.id).toBe(2);
+  });
+
+  it('handles a single dive', () => {
+    const stats = calculateDiveStatistics([dive({ depth: 22, duration: 40 })]);
+
+    expect(stats).toMatchObject({ totalDives: 1, maxDepth: 22, avgDepth: 22, uniqueLocations: 1 });
+  });
+
+  it('does not reorder the caller’s array', () => {
+    const dives = [
+      dive({ id: 1, datetime: '2024-01-01T10:00:00' }),
+      dive({ id: 2, datetime: '2024-06-01T10:00:00' }),
+    ];
+    calculateDiveStatistics(dives);
+
+    expect(dives.map(d => d.id)).toEqual([1, 2]);
+  });
+});
+
+describe('formatDuration', () => {
+  it('shows minutes only under an hour', () => {
+    expect(formatDuration(45)).toBe('45m');
+    expect(formatDuration(0)).toBe('0m');
+  });
+
+  it('splits into hours and minutes past an hour', () => {
+    expect(formatDuration(60)).toBe('1h 0m');
+    expect(formatDuration(135)).toBe('2h 15m');
+  });
+});
+
+describe('getRecentDives', () => {
+  const dives = [
+    dive({ id: 1, datetime: '2024-01-01T10:00:00' }),
+    dive({ id: 2, datetime: '2024-06-01T10:00:00' }),
+    dive({ id: 3, datetime: '2024-03-01T10:00:00' }),
+  ];
+
+  it('returns dives newest first', () => {
+    expect(getRecentDives(dives).map(d => d.id)).toEqual([2, 3, 1]);
+  });
+
+  it('caps the result at the requested count', () => {
+    expect(getRecentDives(dives, 2).map(d => d.id)).toEqual([2, 3]);
+  });
+
+  it('returns everything when there are fewer dives than requested', () => {
+    expect(getRecentDives(dives, 10)).toHaveLength(3);
+  });
+
+  it('does not reorder the caller’s array', () => {
+    getRecentDives(dives);
+    expect(dives.map(d => d.id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('getDivesByMonth', () => {
+  it('groups dives by month in chronological order', () => {
+    const result = getDivesByMonth([
+      dive({ id: 1, datetime: '2024-06-01T10:00:00' }),
+      dive({ id: 2, datetime: '2024-03-15T10:00:00' }),
+      dive({ id: 3, datetime: '2024-03-20T10:00:00' }),
+    ]);
+
+    expect(result).toEqual([
+      { month: 'Mar 2024', count: 2 },
+      { month: 'Jun 2024', count: 1 },
+    ]);
+  });
+
+  it('separates the same month across different years', () => {
+    const result = getDivesByMonth([
+      dive({ id: 1, datetime: '2024-03-01T10:00:00' }),
+      dive({ id: 2, datetime: '2023-03-01T10:00:00' }),
+    ]);
+
+    expect(result).toEqual([
+      { month: 'Mar 2023', count: 1 },
+      { month: 'Mar 2024', count: 1 },
+    ]);
+  });
+
+  it('returns an empty list for no dives', () => {
+    expect(getDivesByMonth([])).toEqual([]);
+  });
+});

--- a/apps/frontend/src/lib/subsurfaceCsvParser.test.ts
+++ b/apps/frontend/src/lib/subsurfaceCsvParser.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubsurfaceCSVParseError, parseSubsurfaceCSV } from './subsurfaceCsvParser';
+
+const HEADER =
+  'dive number,date,time,duration [min],sac [l/min],maxdepth [m],avgdepth [m],mode,' +
+  'airtemp [C],watertemp [C],cylinder size (1) [l],startpressure (1) [bar],endpressure (1) [bar],' +
+  'o2 (1) [%],he (1) [%],location,gps,divemaster,buddy,suit,rating,visibility,notes,weight [kg],tags';
+
+// Columns in Subsurface's export order, so a row reads the same way it would in
+// a real file.
+const row = (over: Record<string, string> = {}) => {
+  const fields: Record<string, string> = {
+    'dive number': '1',
+    date: '2024-03-15',
+    time: '09:30:00',
+    'duration [min]': '45',
+    'sac [l/min]': '18.5',
+    'maxdepth [m]': '28.4',
+    'avgdepth [m]': '16.2',
+    mode: 'OC',
+    'airtemp [C]': '24',
+    'watertemp [C]': '18',
+    'cylinder size (1) [l]': '12',
+    'startpressure (1) [bar]': '210',
+    'endpressure (1) [bar]': '60',
+    'o2 (1) [%]': '21',
+    'he (1) [%]': '0',
+    location: 'Blue Hole',
+    gps: '28.5721 34.5372',
+    divemaster: 'Sam',
+    buddy: 'Jane Diver',
+    suit: '5mm neoprene',
+    rating: '4',
+    visibility: '20',
+    notes: 'Great dive',
+    'weight [kg]': '6',
+    tags: 'reef',
+    ...over,
+  };
+  return HEADER.split(',').map(h => fields[h] ?? '').join(',');
+};
+
+const csv = (...rows: string[]) => [HEADER, ...rows].join('\n');
+
+beforeEach(() => {
+  // The parser warns per bad row by design; keep the suite output readable.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('parseSubsurfaceCSV', () => {
+  it('parses core dive fields', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+
+    expect(dive.location).toBe('Blue Hole');
+    expect(dive.depth).toBe(28.4);
+    expect(dive.duration).toBe(45);
+    expect(dive.buddy).toBe('Jane Diver');
+    expect(dive.notes).toBe('Great dive');
+    expect(dive.rating).toBe(4);
+    expect(dive.diveType).toBe('recreational');
+  });
+
+  // The suite runs in UTC+14, so appending a 'Z' as the old code did would roll
+  // this timestamp back to the 14th.
+  it('keeps the timestamp as site wall-clock time', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+
+    expect(dive.datetime).toBe('2024-03-15T09:30:00');
+  });
+
+  it('parses space-separated GPS coordinates', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+
+    expect(dive.lat).toBeCloseTo(28.5721, 4);
+    expect(dive.lng).toBeCloseTo(34.5372, 4);
+  });
+
+  it('parses negative GPS coordinates', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ gps: '-16.9186 145.7781' })));
+
+    expect(dive.lat).toBeCloseTo(-16.9186, 4);
+    expect(dive.lng).toBeCloseTo(145.7781, 4);
+  });
+
+  it('defaults coordinates to zero when GPS is absent', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ gps: '' })));
+
+    expect(dive.lat).toBe(0);
+    expect(dive.lng).toBe(0);
+  });
+
+  it('accepts MM:SS duration and rounds to whole minutes', () => {
+    expect(parseSubsurfaceCSV(csv(row({ 'duration [min]': '45:30' })))[0].duration).toBe(46);
+    expect(parseSubsurfaceCSV(csv(row({ 'duration [min]': '45:20' })))[0].duration).toBe(45);
+  });
+
+  it('builds an air gas mix from the tank columns', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+    const tank = dive.equipment!.tanks[0];
+
+    expect(tank.size).toBe(12);
+    expect(tank.start_pressure).toBe(210);
+    expect(tank.end_pressure).toBe(60);
+    expect(tank.gas_mix).toMatchObject({ oxygen: 21, helium: 0, nitrogen: 79, name: 'Air' });
+  });
+
+  it('names a nitrox mix from the O2 percentage', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ 'o2 (1) [%]': '32' })));
+
+    expect(dive.equipment!.tanks[0].gas_mix).toMatchObject({ nitrogen: 68, name: 'EANx32' });
+  });
+
+  it('names a trimix from the helium percentage', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ 'o2 (1) [%]': '18', 'he (1) [%]': '45' })));
+
+    expect(dive.equipment!.tanks[0].gas_mix).toMatchObject({ nitrogen: 37, name: 'Trimix 18/45' });
+  });
+
+  it('omits equipment when no cylinder is recorded', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ 'cylinder size (1) [l]': '' })));
+
+    expect(dive.equipment).toBeUndefined();
+  });
+
+  it('records the suit and weights', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+
+    expect(dive.equipment!.wetsuit).toMatchObject({ type: 'wetsuit', material: '5mm neoprene' });
+    expect(dive.equipment!.weights).toBe(6);
+  });
+
+  it('marks the suit as none when the column is blank', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ suit: '' })));
+
+    expect(dive.equipment!.wetsuit!.type).toBe('none');
+  });
+
+  it('parses conditions', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row()));
+
+    expect(dive.conditions).toEqual({
+      airTemp: 24,
+      waterTemp: { surface: 18, bottom: 18 },
+      visibility: 20,
+    });
+  });
+
+  it('omits conditions entirely when no readings are present', () => {
+    const [dive] = parseSubsurfaceCSV(
+      csv(row({ 'airtemp [C]': '', 'watertemp [C]': '', visibility: '' })),
+    );
+
+    expect(dive.conditions).toBeUndefined();
+  });
+
+  it('keeps partial conditions when only some readings are present', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ 'airtemp [C]': '', visibility: '' })));
+
+    expect(dive.conditions).toEqual({
+      airTemp: undefined,
+      waterTemp: { surface: 18, bottom: 18 },
+      visibility: undefined,
+    });
+  });
+
+  it('handles quoted fields containing commas', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ notes: '"Strong current, aborted early"' })));
+
+    expect(dive.notes).toBe('Strong current, aborted early');
+  });
+
+  it('handles escaped quotes inside a quoted field', () => {
+    const [dive] = parseSubsurfaceCSV(csv(row({ notes: '"Saw a ""cleaner"" wrasse"' })));
+
+    expect(dive.notes).toBe('Saw a "cleaner" wrasse');
+  });
+
+  // One unparseable row shouldn't cost the user the rest of the import.
+  it('skips invalid rows and keeps the valid ones', () => {
+    const dives = parseSubsurfaceCSV(
+      csv(row(), row({ 'dive number': '2', 'maxdepth [m]': '' }), row({ 'dive number': '3' })),
+    );
+
+    expect(dives).toHaveLength(2);
+  });
+
+  it.each([
+    ['a missing location', { location: '' }],
+    ['a missing date', { date: '' }],
+    ['a missing time', { time: '' }],
+    ['a zero depth', { 'maxdepth [m]': '0' }],
+    ['a negative depth', { 'maxdepth [m]': '-5' }],
+    ['a zero duration', { 'duration [min]': '0' }],
+  ])('rejects a row with %s', (_label, over) => {
+    expect(() => parseSubsurfaceCSV(csv(row(over)))).toThrow(SubsurfaceCSVParseError);
+  });
+
+  it('ignores blank lines', () => {
+    expect(parseSubsurfaceCSV([HEADER, row(), '', '  '].join('\n'))).toHaveLength(1);
+  });
+
+  it('rejects a file with no data rows', () => {
+    expect(() => parseSubsurfaceCSV(HEADER)).toThrow(/at least a header and one data row/);
+  });
+
+  it('names the headers that are missing', () => {
+    expect(() => parseSubsurfaceCSV('date,time\n2024-03-15,09:30:00')).toThrow(
+      /Missing required headers:.*dive number/,
+    );
+  });
+});

--- a/apps/frontend/src/lib/subsurfaceCsvParser.ts
+++ b/apps/frontend/src/lib/subsurfaceCsvParser.ts
@@ -140,8 +140,9 @@ function parseSubsurfaceCSVRow(row: SubsurfaceCSVRow): Dive | null {
       throw new Error(`Missing date or time: date="${dateStr}", time="${timeStr}"`);
     }
     
-    // Combine date and time (Subsurface format: YYYY-MM-DD and HH:MM:SS)
-    const datetime = `${dateStr}T${timeStr}.000Z`;
+    // Combine date and time (Subsurface format: YYYY-MM-DD and HH:MM:SS).
+    // These are wall-clock times at the dive site, so no timezone is attached.
+    const datetime = `${dateStr}T${timeStr}`;
     
     // Parse location
     const location = row.location?.trim();

--- a/apps/frontend/src/lib/uddfParser.test.ts
+++ b/apps/frontend/src/lib/uddfParser.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest';
+import { UDDFParseError, getUDDFImportSummary, parseUDDFFile, validateUDDFFile } from './uddfParser';
+import type { Dive } from './dives';
+
+const uddfFile = (xml: string, name = 'dives.uddf') =>
+  new File([xml], name, { type: 'application/xml' });
+
+// A minimal but structurally realistic UDDF document. Dive computers emit SI
+// base units here: temperature in Kelvin, pressure in Pascal, duration in
+// seconds.
+const sampleUDDF = `<?xml version="1.0" encoding="UTF-8"?>
+<uddf version="3.2.0">
+  <divesite>
+    <site id="site-1">
+      <name>Blue Hole</name>
+      <geography>
+        <latitude>28.5721</latitude>
+        <longitude>34.5372</longitude>
+      </geography>
+    </site>
+  </divesite>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2024-03-15T09:30:00</datetime>
+          <link ref="site-1"/>
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <divetime>0</divetime>
+            <depth>0</depth>
+            <temperature>295.15</temperature>
+            <tankpressure>20000000</tankpressure>
+          </waypoint>
+          <waypoint>
+            <divetime>600</divetime>
+            <depth>28.4</depth>
+            <temperature>291.15</temperature>
+            <tankpressure>15000000</tankpressure>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>28.42</greatestdepth>
+          <diveduration>2700</diveduration>
+          <buddy>
+            <personal>
+              <firstname>Jane</firstname>
+              <lastname>Diver</lastname>
+            </personal>
+          </buddy>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>`;
+
+describe('parseUDDFFile', () => {
+  it('parses a dive with site, depth, duration and buddy', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+
+    expect(dive.location).toBe('Blue Hole');
+    expect(dive.lat).toBeCloseTo(28.5721, 4);
+    expect(dive.lng).toBeCloseTo(34.5372, 4);
+    expect(dive.depth).toBe(28.4);
+    expect(dive.buddy).toBe('Jane Diver');
+  });
+
+  it('converts dive duration from seconds to whole minutes', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+
+    expect(dive.duration).toBe(45);
+  });
+
+  // UDDF temperatures are Kelvin. Reading 295.15 as celsius would show a 295°C
+  // dive, and reading 20000000 Pa as bar would show a 20-million-bar tank.
+  it('converts sample temperature from Kelvin to celsius', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+
+    expect(dive.samples?.[0].temperature).toBe(22);
+    expect(dive.samples?.[1].temperature).toBe(18);
+  });
+
+  it('converts sample pressure from Pascal to bar', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+
+    expect(dive.samples?.[0].pressure).toBe(200);
+    expect(dive.samples?.[1].pressure).toBe(150);
+  });
+
+  // The suite runs in UTC+14, so anything that routes the timestamp through
+  // toISOString() lands on the previous day and fails here.
+  it('keeps the timestamp as site wall-clock time', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+
+    expect(dive.datetime).toBe('2024-03-15T09:30:00');
+  });
+
+  it('accepts a space separator and a missing seconds component', async () => {
+    const xml = sampleUDDF.replace('2024-03-15T09:30:00', '2024-03-15 09:30');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.datetime).toBe('2024-03-15T09:30:00');
+  });
+
+  it('ignores a trailing timezone offset rather than shifting the time', async () => {
+    const xml = sampleUDDF.replace('2024-03-15T09:30:00', '2024-03-15T09:30:00+02:00');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.datetime).toBe('2024-03-15T09:30:00');
+  });
+
+  it('sorts samples by time', async () => {
+    const [dive] = await parseUDDFFile(uddfFile(sampleUDDF));
+    const times = dive.samples!.map(s => s.time);
+
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  // A single flat-lining sensor should cost that one reading, not the import.
+  it('drops implausible sensor readings but keeps the sample', async () => {
+    const xml = sampleUDDF
+      .replace('<temperature>295.15</temperature>', '<temperature>0</temperature>')
+      .replace('<tankpressure>20000000</tankpressure>', '<tankpressure>-1</tankpressure>');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.samples).toHaveLength(2);
+    expect(dive.samples?.[0].temperature).toBeUndefined();
+    expect(dive.samples?.[0].pressure).toBeUndefined();
+    expect(dive.samples?.[0].depth).toBe(0);
+  });
+
+  it('omits optional readings that are absent from the file', async () => {
+    const xml = sampleUDDF
+      .replace(/<temperature>[^<]*<\/temperature>/g, '')
+      .replace(/<tankpressure>[^<]*<\/tankpressure>/g, '');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.samples?.[0].temperature).toBeUndefined();
+    expect(dive.samples?.[0].pressure).toBeUndefined();
+  });
+
+  it('skips dives with neither depth nor duration', async () => {
+    const xml = sampleUDDF
+      .replace('<greatestdepth>28.42</greatestdepth>', '<greatestdepth>0</greatestdepth>')
+      .replace('<diveduration>2700</diveduration>', '<diveduration>0</diveduration>');
+
+    await expect(parseUDDFFile(uddfFile(xml))).resolves.toEqual([]);
+  });
+
+  it('parses multiple dives in one repetition group', async () => {
+    const secondDive = `
+      <dive id="dive-2">
+        <informationbeforedive>
+          <datetime>2024-03-16T11:00:00</datetime>
+          <link ref="site-1"/>
+        </informationbeforedive>
+        <informationafterdive>
+          <greatestdepth>18.0</greatestdepth>
+          <diveduration>3000</diveduration>
+        </informationafterdive>
+      </dive>`;
+    const xml = sampleUDDF.replace('</repetitiongroup>', `${secondDive}</repetitiongroup>`);
+    const dives = await parseUDDFFile(uddfFile(xml));
+
+    expect(dives).toHaveLength(2);
+    expect(dives.map(d => d.id)).toEqual([1, 2]);
+    expect(dives[1].datetime).toBe('2024-03-16T11:00:00');
+    expect(dives[1].buddy).toBeUndefined();
+  });
+
+  it('falls back to the first known site when the link ref is unknown', async () => {
+    const xml = sampleUDDF.replace('<link ref="site-1"/>', '<link ref="site-missing"/>');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.location).toBe('Blue Hole');
+  });
+
+  it('falls back to a placeholder location when there are no sites', async () => {
+    const xml = sampleUDDF.replace(/<divesite>[\s\S]*<\/divesite>/, '');
+    const [dive] = await parseUDDFFile(uddfFile(xml));
+
+    expect(dive.location).toBe('Unknown Location');
+    expect(dive.lat).toBe(0);
+    expect(dive.lng).toBe(0);
+  });
+
+  it('rejects a document with no uddf root', async () => {
+    await expect(parseUDDFFile(uddfFile('<notuddf></notuddf>'))).rejects.toThrow(UDDFParseError);
+  });
+
+  it('keeps parsing when one dive in the group is malformed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const xml = sampleUDDF.replace('</repetitiongroup>', '<dive id="dive-bad"></dive></repetitiongroup>');
+
+    await expect(parseUDDFFile(uddfFile(xml))).resolves.toHaveLength(1);
+    warn.mockRestore();
+  });
+});
+
+describe('validateUDDFFile', () => {
+  it('accepts a non-empty .uddf file', () => {
+    expect(validateUDDFFile(uddfFile(sampleUDDF))).toBe(true);
+  });
+
+  it('is case-insensitive about the extension', () => {
+    expect(validateUDDFFile(uddfFile(sampleUDDF, 'DIVES.UDDF'))).toBe(true);
+  });
+
+  it('rejects other extensions', () => {
+    expect(validateUDDFFile(uddfFile(sampleUDDF, 'dives.xml'))).toBe(false);
+  });
+
+  it('rejects an empty file', () => {
+    expect(validateUDDFFile(uddfFile('', 'dives.uddf'))).toBe(false);
+  });
+
+  it('rejects files over the 10MB limit', () => {
+    const tooBig = new File(['x'], 'dives.uddf');
+    Object.defineProperty(tooBig, 'size', { value: 10 * 1024 * 1024 + 1 });
+
+    expect(validateUDDFFile(tooBig)).toBe(false);
+  });
+});
+
+describe('getUDDFImportSummary', () => {
+  const dive = (over: Partial<Dive> = {}): Dive => ({
+    id: 1,
+    datetime: '2024-03-15T09:30:00',
+    location: 'Blue Hole',
+    depth: 28.4,
+    duration: 45,
+    lat: 0,
+    lng: 0,
+    ...over,
+  });
+
+  it('reports when nothing was found', () => {
+    expect(getUDDFImportSummary([])).toBe('No valid dives found in UDDF file');
+  });
+
+  it('uses singular wording for one dive at one location', () => {
+    expect(getUDDFImportSummary([dive()])).toContain('Found 1 dive from 1 location');
+  });
+
+  it('uses plural wording and counts distinct locations', () => {
+    const summary = getUDDFImportSummary([
+      dive(),
+      dive({ id: 2, location: 'Thistlegorm' }),
+      dive({ id: 3, location: 'Blue Hole' }),
+    ]);
+
+    expect(summary).toContain('Found 3 dives from 2 locations');
+  });
+});

--- a/apps/frontend/src/lib/uddfParser.ts
+++ b/apps/frontend/src/lib/uddfParser.ts
@@ -16,6 +16,13 @@ interface UDDFDivesite {
   site: UDDFSite | UDDFSite[];
 }
 
+interface UDDFBuddy {
+  personal?: {
+    firstname?: string;
+    lastname?: string;
+  };
+}
+
 interface UDDFDive {
   '@_id': string;
   informationbeforedive?: {
@@ -29,12 +36,7 @@ interface UDDFDive {
   informationafterdive?: {
     greatestdepth?: number;
     diveduration?: number;
-    buddy?: {
-      personal?: {
-        firstname?: string;
-        lastname?: string;
-      };
-    }[];
+    buddy?: UDDFBuddy | UDDFBuddy[];
   };
   samples?: {
     waypoint?: Array<{
@@ -192,10 +194,12 @@ const parseUDDFDive = (
   const durationSeconds = Number(afterDive?.diveduration) || 0;
   const duration = Math.round(durationSeconds / 60); // Convert seconds to minutes
 
-  // Extract buddy information
+  // Extract buddy information. A lone <buddy> element parses to an object
+  // rather than an array, which is by far the most common case.
   let buddy = '';
-  if (afterDive?.buddy && Array.isArray(afterDive.buddy)) {
-    const buddyInfo = afterDive.buddy[0]?.personal;
+  if (afterDive?.buddy) {
+    const buddies = Array.isArray(afterDive.buddy) ? afterDive.buddy : [afterDive.buddy];
+    const buddyInfo = buddies[0]?.personal;
     if (buddyInfo) {
       buddy = `${buddyInfo.firstname || ''} ${buddyInfo.lastname || ''}`.trim();
     }
@@ -269,10 +273,16 @@ const parseUDDFDive = (
 const KELVIN_OFFSET = 273.15;
 const PASCAL_PER_BAR = 100000;
 
+// A dropped-out sensor typically reports 0 K, which is why the lower bound is a
+// plausible ambient temperature rather than absolute zero: -273.15 is a missing
+// reading, not a cold dive.
+const MIN_PLAUSIBLE_CELSIUS = -20;
+const MAX_PLAUSIBLE_CELSIUS = 100;
+
 const kelvinToCelsius = (kelvin: number): number | undefined => {
   const celsius = kelvin - KELVIN_OFFSET;
   // Guard against sensor dropouts, so one bad sample can't fail the whole import
-  if (!Number.isFinite(celsius) || celsius < -273.15 || celsius > 100) {
+  if (!Number.isFinite(celsius) || celsius < MIN_PLAUSIBLE_CELSIUS || celsius > MAX_PLAUSIBLE_CELSIUS) {
     return undefined;
   }
   return Math.round(celsius * 100) / 100;

--- a/apps/frontend/src/lib/uddfParser.ts
+++ b/apps/frontend/src/lib/uddfParser.ts
@@ -233,10 +233,10 @@ const parseUDDFDive = (
     samples = waypoints
       .filter(wp => wp.divetime !== undefined && wp.depth !== undefined)
       .map(wp => ({
-        time: Number(wp.divetime!), // Ensure time is a number
+        time: Math.round(Number(wp.divetime!)), // Whole seconds from dive start
         depth: Number(wp.depth!), // Ensure depth is a number
-        temperature: wp.temperature !== undefined ? Number(wp.temperature) : undefined, // Convert to number if present
-        pressure: wp.tankpressure !== undefined ? Number(wp.tankpressure) : undefined, // Convert to number if present
+        temperature: wp.temperature !== undefined ? kelvinToCelsius(Number(wp.temperature)) : undefined,
+        pressure: wp.tankpressure !== undefined ? pascalToBar(Number(wp.tankpressure)) : undefined,
       }))
       .sort((a, b) => a.time - b.time); // Sort by time
     
@@ -264,19 +264,53 @@ const parseUDDFDive = (
   };
 };
 
-const parseUDDFDateTime = (dateString: string): string => {
-  try {
-    // UDDF dates can be in various formats, commonly ISO 8601
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) {
-      throw new Error('Invalid date');
-    }
-    
-    return date.toISOString();
-  } catch {
-    // Fallback to current date if parsing fails
-    return new Date().toISOString();
+// UDDF stores measurements in SI base units: temperature in Kelvin and
+// pressure in Pascal. The rest of the app works in celsius and bar.
+const KELVIN_OFFSET = 273.15;
+const PASCAL_PER_BAR = 100000;
+
+const kelvinToCelsius = (kelvin: number): number | undefined => {
+  const celsius = kelvin - KELVIN_OFFSET;
+  // Guard against sensor dropouts, so one bad sample can't fail the whole import
+  if (!Number.isFinite(celsius) || celsius < -273.15 || celsius > 100) {
+    return undefined;
   }
+  return Math.round(celsius * 100) / 100;
+};
+
+const pascalToBar = (pascal: number): number | undefined => {
+  const bar = pascal / PASCAL_PER_BAR;
+  if (!Number.isFinite(bar) || bar < 0 || bar > 1000) {
+    return undefined;
+  }
+  return Math.round(bar * 100) / 100;
+};
+
+// Dive times are wall-clock times at the dive site, and the rest of the app
+// stores them that way. UDDF timestamps carry either no zone at all or the
+// computer's own offset, so keep the components as written rather than letting
+// them get shifted into UTC by the importing machine's timezone.
+const UDDF_DATETIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/;
+
+const parseUDDFDateTime = (dateString: string): string => {
+  const match = UDDF_DATETIME.exec(dateString.trim());
+  if (match) {
+    const [, year, month, day, hours, minutes, seconds = '00'] = match;
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  }
+
+  // Fallback for any format we don't recognise
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) {
+    return formatLocalDateTime(new Date());
+  }
+  return formatLocalDateTime(date);
+};
+
+const formatLocalDateTime = (date: Date): string => {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 };
 
 export const validateUDDFFile = (file: File): boolean => {

--- a/apps/frontend/src/lib/unitConversions.test.ts
+++ b/apps/frontend/src/lib/unitConversions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertDepth,
+  convertDistance,
+  convertPressure,
+  convertTemperature,
+  convertVolume,
+  convertWeight,
+  formatDepth,
+  formatPressure,
+  formatTemperature,
+  formatValue,
+} from './unitConversions';
+
+// Conversions are the one place where a wrong answer still looks plausible:
+// 30ft reads as a perfectly reasonable dive depth even when it should be 98ft.
+// These lock down known-correct reference values rather than re-deriving the
+// formula, which would just repeat any mistake in the implementation.
+describe('convertDepth', () => {
+  it('converts meters to feet', () => {
+    expect(convertDepth(30, 'meters', 'feet')).toBe(98.4);
+    expect(convertDepth(1, 'meters', 'feet')).toBe(3.3);
+  });
+
+  it('converts feet to meters', () => {
+    expect(convertDepth(100, 'feet', 'meters')).toBe(30.5);
+  });
+
+  it('returns the value unchanged when units match', () => {
+    expect(convertDepth(18.5, 'meters', 'meters')).toBe(18.5);
+    expect(convertDepth(18.5, 'feet', 'feet')).toBe(18.5);
+  });
+
+  it('handles zero', () => {
+    expect(convertDepth(0, 'meters', 'feet')).toBe(0);
+  });
+
+  it('round-trips within rounding tolerance', () => {
+    const feet = convertDepth(40, 'meters', 'feet');
+    expect(convertDepth(feet, 'feet', 'meters')).toBeCloseTo(40, 0);
+  });
+});
+
+describe('convertTemperature', () => {
+  it('converts celsius to fahrenheit at reference points', () => {
+    expect(convertTemperature(0, 'celsius', 'fahrenheit')).toBe(32);
+    expect(convertTemperature(100, 'celsius', 'fahrenheit')).toBe(212);
+    expect(convertTemperature(-40, 'celsius', 'fahrenheit')).toBe(-40);
+  });
+
+  it('converts fahrenheit to celsius at reference points', () => {
+    expect(convertTemperature(32, 'fahrenheit', 'celsius')).toBe(0);
+    expect(convertTemperature(212, 'fahrenheit', 'celsius')).toBe(100);
+  });
+
+  it('handles typical water temperatures', () => {
+    expect(convertTemperature(18, 'celsius', 'fahrenheit')).toBe(64.4);
+  });
+
+  it('preserves sub-zero temperatures rather than clamping', () => {
+    expect(convertTemperature(-5, 'celsius', 'fahrenheit')).toBe(23);
+  });
+});
+
+describe('convertDistance', () => {
+  it('converts kilometers to miles', () => {
+    expect(convertDistance(10, 'kilometers', 'miles')).toBe(6.2);
+  });
+
+  it('converts miles to kilometers', () => {
+    expect(convertDistance(10, 'miles', 'kilometers')).toBe(16.1);
+  });
+});
+
+describe('convertWeight', () => {
+  it('converts kilograms to pounds', () => {
+    expect(convertWeight(10, 'kilograms', 'pounds')).toBe(22);
+  });
+
+  it('converts pounds to kilograms', () => {
+    expect(convertWeight(10, 'pounds', 'kilograms')).toBe(4.5);
+  });
+});
+
+describe('convertPressure', () => {
+  // Pressure is the one conversion that rounds to a whole number going up,
+  // because a psi reading with a decimal is not something a gauge shows.
+  it('converts bar to whole psi', () => {
+    expect(convertPressure(200, 'bar', 'psi')).toBe(2901);
+    expect(convertPressure(1, 'bar', 'psi')).toBe(15);
+  });
+
+  it('converts psi to bar', () => {
+    expect(convertPressure(3000, 'psi', 'bar')).toBe(206.8);
+  });
+});
+
+describe('convertVolume', () => {
+  it('converts liters to cubic feet', () => {
+    expect(convertVolume(12, 'liters', 'cubic_feet')).toBe(0.4);
+  });
+
+  it('converts cubic feet to liters', () => {
+    expect(convertVolume(80, 'cubic_feet', 'liters')).toBe(2265.3);
+  });
+});
+
+// The format* helpers assume the stored value is always metric, so passing an
+// imperial unit means "convert, then label" - not "label as-is".
+describe('formatting', () => {
+  it('converts from the stored metric value before labelling', () => {
+    expect(formatDepth(30, 'meters')).toBe('30.0m');
+    expect(formatDepth(30, 'feet')).toBe('98.4ft');
+  });
+
+  it('respects the precision argument', () => {
+    expect(formatDepth(30, 'meters', 0)).toBe('30m');
+    expect(formatTemperature(18.456, 'celsius', 2)).toBe('18.46°C');
+  });
+
+  it('defaults pressure to whole numbers', () => {
+    expect(formatPressure(200, 'bar')).toBe('200bar');
+    expect(formatPressure(200, 'psi')).toBe('2901psi');
+  });
+
+  it('dispatches to the right formatter by type', () => {
+    expect(formatValue(30, 'depth', 'feet')).toBe('98.4ft');
+    expect(formatValue(0, 'temperature', 'fahrenheit')).toBe('32.0°F');
+    expect(formatValue(10, 'distance', 'miles')).toBe('6.2mi');
+    expect(formatValue(10, 'weight', 'pounds')).toBe('22.0lbs');
+    expect(formatValue(200, 'pressure', 'psi')).toBe('2901psi');
+    expect(formatValue(12, 'volume', 'cubic_feet')).toBe('0.4ft³');
+  });
+});

--- a/apps/frontend/src/pages/DiveLog.tsx
+++ b/apps/frontend/src/pages/DiveLog.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -23,12 +25,19 @@ const DiveLog = () => {
   const dives = useDiveStore((state) => state.dives);
   const deleteDive = useDiveStore((state) => state.deleteDive);
   const importDives = useDiveStore((state) => state.importDives);
+  const clearAllDives = useDiveStore((state) => state.clearAllDives);
+  const clearError = useDiveStore((state) => state.error);
   const { settings } = useSettingsStore();
   const stats = calculateDiveStatistics(dives);
   const [selectedDive, setSelectedDive] = useState<Dive | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+  const [clearFailed, setClearFailed] = useState(false);
 
+  // The matching backend route only exists outside release mode
+  const isDevBuild = import.meta.env.DEV;
 
   const handleRowClick = (dive: Dive) => {
     setSelectedDive(dive);
@@ -45,6 +54,27 @@ const DiveLog = () => {
     setShowImport(false);
   };
 
+  const handleClearAllDives = async () => {
+    setIsClearing(true);
+    setClearFailed(false);
+    try {
+      const cleared = await clearAllDives();
+      if (cleared) {
+        setShowClearConfirm(false);
+      } else {
+        setClearFailed(true);
+      }
+    } finally {
+      setIsClearing(false);
+    }
+  };
+
+  const handleClearDialogChange = (open: boolean) => {
+    if (isClearing) return;
+    setShowClearConfirm(open);
+    if (!open) setClearFailed(false);
+  };
+
   return (
     <div className="space-y-8">
       {/* Hero Section */}
@@ -59,12 +89,27 @@ const DiveLog = () => {
                 Track and analyze your diving adventures with comprehensive logging and insights
               </p>
             </div>
-            <div className="flex lg:flex-shrink-0">
-              <Button 
-                variant="outline" 
+            <div className="flex flex-wrap gap-3 lg:flex-shrink-0 lg:justify-end">
+              {isDevBuild && (
+                <Button
+                  variant="outline"
+                  size="lg"
+                  onClick={() => {
+                    setClearFailed(false);
+                    setShowClearConfirm(true);
+                  }}
+                  disabled={dives.length === 0}
+                  title="Development only: removes every dive from the database"
+                  className="bg-white border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800 px-8 py-4 text-base font-medium shadow-sm"
+                >
+                  Delete All Dives (dev)
+                </Button>
+              )}
+              <Button
+                variant="outline"
                 size="lg"
                 onClick={() => setShowImport(true)}
-                className="bg-white border-slate-300 text-slate-700 hover:bg-slate-50 px-8 py-4 text-base font-medium shadow-sm mr-6"
+                className="bg-white border-slate-300 text-slate-700 hover:bg-slate-50 px-8 py-4 text-base font-medium shadow-sm"
               >
                 Import
               </Button>
@@ -178,8 +223,42 @@ const DiveLog = () => {
           <DiveImport onImport={handleImportDives} />
         </DialogContent>
       </Dialog>
+
+      <Dialog open={showClearConfirm} onOpenChange={handleClearDialogChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete all dives?</DialogTitle>
+            <DialogDescription>
+              This permanently deletes all {dives.length} dive
+              {dives.length === 1 ? "" : "s"} from the database. It cannot be
+              undone. Dive sites and settings are kept.
+            </DialogDescription>
+            {clearFailed && (
+              <p role="alert" className="text-sm text-red-600">
+                Could not delete the dives. {clearError ?? "Please try again."}
+              </p>
+            )}
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowClearConfirm(false)}
+              disabled={isClearing}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleClearAllDives}
+              disabled={isClearing}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {isClearing ? "Clearing..." : `Delete ${dives.length} dive${dives.length === 1 ? "" : "s"}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };
 
-export default DiveLog; 
+export default DiveLog;

--- a/apps/frontend/src/store/diveStore.ts
+++ b/apps/frontend/src/store/diveStore.ts
@@ -21,6 +21,7 @@ interface DiveState {
   editDive: (dive: Dive) => Promise<void>;
   deleteDive: (id: number) => Promise<void>;
   importDives: (dives: Dive[]) => Promise<void>;
+  clearAllDives: () => Promise<boolean>;
   loadFromBackend: () => Promise<void>;
   processOfflineQueue: () => Promise<void>;
   setOnlineStatus: (online: boolean) => void;
@@ -176,6 +177,20 @@ const useDiveStore = create<DiveState>()((set, get) => ({
     }
   },
 
+  clearAllDives: async () => {
+    set({ isLoading: true, error: null });
+
+    const result = await divesApi.deleteAllDives();
+    if (result.error) {
+      set({ error: result.error, isLoading: false });
+      return false;
+    }
+
+    // Drop any queued work as well, so a reset does not resurrect old dives
+    set({ dives: [], offlineQueue: [], isLoading: false, error: null });
+    return true;
+  },
+
   loadFromBackend: async () => {
     set({ isLoading: true, error: null });
 
@@ -241,4 +256,4 @@ const useDiveStore = create<DiveState>()((set, get) => ({
   },
 }));
 
-export default useDiveStore; 
+export default useDiveStore;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from "@tailwindcss/vite"
 
@@ -13,6 +13,20 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // Dive times are wall-clock times at the dive site. Running the suite in a
+    // far-from-UTC zone means an accidental UTC conversion shifts the date and
+    // fails the test, rather than passing by luck on a UTC machine.
+    env: {
+      TZ: 'Pacific/Kiritimati',
+    },
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**/*.ts'],
     },
   },
 })


### PR DESCRIPTION
## Summary

Three commits, each independently reviewable.

**`fa203e4` Persist dive conditions, type, rating and safety stops**

Several dive fields were accepted by the API but never reached the database:

- The repository layer omitted `conditions`, `dive_type`, `rating` and `safety_stops` from its select, insert and update statements, so they were dropped on every write and always came back empty on read.
- The frontend sent camelCase field names to a snake_case API. Go ignores unknown JSON keys, so `conditions`, `diveType` and `safetyStops` were discarded without an error anywhere.
- UDDF sample temperature was read as celsius when the format stores Kelvin, and pressure as bar when the format stores Pascal.
- Dive timestamps were being shifted into UTC based on the importing machine's timezone, rather than kept as wall-clock time at the dive site.

Also adds a `DeleteAllDives` helper for resetting local test data. The route is deliberately only registered outside release mode.

**`7d4bd28` Add frontend test suite**

The frontend had no tests and no test runner, while holding the import parsers and unit conversions — logic where a wrong answer still looks plausible and so fails quietly.

99 tests via Vitest:

| Module | Coverage |
| --- | --- |
| `diveStats.ts` | 100% |
| `subsurfaceCsvParser.ts` | 96% |
| `uddfParser.ts` | 86% |
| `unitConversions.ts` | 85% |

The suite runs at `TZ=Pacific/Kiritimati` (UTC+14) on purpose. Dive times are wall-clock times at the dive site, so an accidental UTC conversion shifts the date and fails a test instead of passing by luck on a UTC machine.

Two bugs this surfaced, fixed in the same commit:

- A single `<buddy>` element parses to an object rather than an array, so the `Array.isArray` check meant the buddy was never read for the common single-buddy case.
- The sample temperature guard used absolute zero as its lower bound, so a dropped-out sensor reporting 0 K passed through as a -273.15C reading.

**`22c203f` Add CI workflow**

Nothing ran the test suites automatically, so the backend tests that already existed were not gating anything. Backend runs tidy/build/vet/test with `-race`; frontend runs lint, build (which runs `tsc -b`) and tests with coverage.

## Notes

Coverage has to run under Node — Bun's runtime does not implement the `node:inspector` API that `@vitest/coverage-v8` depends on, and reports 0% otherwise. `bun run test` is unaffected. This is documented in CLAUDE.md and is why CI invokes vitest through npx.

## Verification

All steps were run locally: 99 frontend tests pass, all 7 Go packages pass with `-race`, `go mod tidy` leaves no diff, `go vet` is clean, `tsc -b` is clean, and lint is back to its one pre-existing warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)